### PR TITLE
carnivorous potted plant info

### DIFF
--- a/src/relay/chit_brickGear.ash
+++ b/src/relay/chit_brickGear.ash
@@ -331,6 +331,10 @@ string gearName(item it, slot s) {
 			}
 			notes += augSkillsCast + "/" + augSkillsCastable + " used";
 			break;
+		case $item[carnivorous potted plant]:
+			int plantFreeKills = get_property("_carnivorousPottedPlantWins").to_int();
+			notes = plantFreeKills + " free kills [" +  (1.0 / (20.0 + plantFreeKills) * 100) + "% swallow chance]";
+			break;
 	}
 
 	if(equipped_item(s) == it && s == $slot[off-hand] && vars["chit.gear.lattereminder"].to_boolean() && my_location().latteDropAvailable()) {


### PR DESCRIPTION
# Description

adds free kill info and activation rate for carnivorous potted plant if equipped. The degrading chance of a free kill was dev leaked a bit ago and is not flat.

## Screenshots

![image](https://github.com/loathers/ChIT/assets/1320480/262b0a99-f08e-4862-8f25-39d38905f1a5)

## Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/ChIT/tree/main) or have a good reason not to.
