### PR TITLE
improve wereprofessor transform display

### DIFF
--- a/src/relay/charpane.ash
+++ b/src/relay/charpane.ash
@@ -2797,12 +2797,20 @@ void addWildfire(buffer result) {
 void addWereProfessor(buffer result) {
 	matcher transform = create_matcher("<td align=right>Until Transform:</td><td align=left><b>([\\d,]+)</b>", chitSource["stats"]);
 	if (transform.find()) {
-		result.append('<tr><td class="label">Transform</td><td class="info">');
+		result.append('<tr><td class="label">');
+		if (have_effect($effect[Savage Beast]) > 0)
+			result.append('Prof');
+		else
+			result.append('Wolf');
+		result.append(' In</td><td class="info">');
 		result.append(transform.group(1));
+		result.append(' turn');
+		if (to_int(transform.group(1)) != 1)
+			result.append('s');
 		if(to_boolean(vars["chit.stats.showbars"])) {
 			result.append('<td class="progress"><div class="progressbox">');
 			result.append('<div class="progressbar" style="width:');
-			result.append(100 - 2 * to_int(transform.group(1)));
+			result.append(2 * to_int(transform.group(1)));
 			result.append('%"></div></div></td>');
 		}
 		else 


### PR DESCRIPTION
# Description

Change the label for the turns countdown before transforming to prof/wolf for clarity. Now if you are the professor, it will say "Wolf In X turns". If you are the wolf, it will say "Prof In X turns" ('s' is only added if turn count is not 1). Also the progress bar has been inverted to begin full after transformation and empty as the turn count decreases.

## Screenshots

![image](https://github.com/loathers/ChIT/assets/17497392/f8fb9251-aef6-45a3-a1b5-bcbb669af1af)

## Checklist:

- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/ChIT/tree/main) or have a good reason not to.
