### PR TITLE
feat: recognise the apriling band tuba charpane message

### DIFF
--- a/src/relay/charpane.ash
+++ b/src/relay/charpane.ash
@@ -1321,6 +1321,7 @@ void bakeEffects() {
 			new noncommod("cincho.gif", "cincho fiesta exit", "exit mode on your cincho"),
 			new noncommod("jparka2.gif", "spikolodon spike", "spikes are scaring away most monsters"),
 			new noncommod("pillminder.gif", "sneakisol", "avoiding fights until something cool happens"),
+			new noncommod("tuba.gif", "apriling band tuba", "tuba playing has scared away most monsters"),
 		};
 
 		foreach i,noncom in nomcommods {


### PR DESCRIPTION
# Description

Adds the Apriling band tuba play to the known noncombat forcers.

## Screenshots

![image](https://github.com/loathers/ChIT/assets/25565697/726a30bd-9e3d-4604-8939-79b07428c870)

## Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/ChIT/tree/main) or have a good reason not to.
