### PR TITLE
add soup_weight to familiar weight display

### DIFF
--- a/src/relay/chit_brickFamiliar.ash
+++ b/src/relay/chit_brickFamiliar.ash
@@ -1073,7 +1073,10 @@ void bakeFamiliar() {
 
 	//Get Familiar Weight
 	if (myfam != $familiar[none]) {
-		famweight = to_string(familiar_weight(myfam) + weight_adjustment());
+		// familiar_weight($familiar) returns the current experience based weight
+		// weight_adjustment() returns the current bonuses from equipment & buffs etc.
+		// fam.soup_weight tracks how much extra intrinsic weight the familiar has added from TTT soup (resets on ascension)
+		famweight = to_string(familiar_weight(myfam) + weight_adjustment() + fam.soup_weight);
 	}
 
 	//Get equipment info

--- a/src/relay/chit_brickFamiliar.ash
+++ b/src/relay/chit_brickFamiliar.ash
@@ -1076,7 +1076,7 @@ void bakeFamiliar() {
 		// familiar_weight($familiar) returns the current experience based weight
 		// weight_adjustment() returns the current bonuses from equipment & buffs etc.
 		// fam.soup_weight tracks how much extra intrinsic weight the familiar has added from TTT soup (resets on ascension)
-		famweight = to_string(familiar_weight(myfam) + weight_adjustment() + fam.soup_weight);
+		famweight = to_string(familiar_weight(myfam) + weight_adjustment() + myfam.soup_weight);
 	}
 
 	//Get equipment info


### PR DESCRIPTION
# Description

Familiar weight will now add the value from $familiar.soup_weight to the familiar brick.

## Screenshots

Without: ![image](https://github.com/user-attachments/assets/e0b85455-b39e-4771-9abd-9e3f855a68e8)

With: ![image](https://github.com/user-attachments/assets/08a2bf8e-13fc-4dfd-8acb-edf941587c44)

## Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/ChIT/tree/main) or have a good reason not to.
