### PR TITLE
fix: update ensorcel images for cloudfront move

### DIFF
--- a/src/relay/chit_brickFamiliar.ash
+++ b/src/relay/chit_brickFamiliar.ash
@@ -967,7 +967,7 @@ void FamVampyre() {
 		result.append('</tbody></table>');
 	}
 
-	matcher id = create_matcher('https://d2uyhvukfffg5a.cloudfront.net/(.+?)><br>(.+?)<br><font color=blue><b>(.+?)</font>', chitSource["familiar"]);
+	matcher id = create_matcher('<img src=(?:.+?)/(adventureimages/.+?)><br>(.+?)<br><font color=blue><b>(.+?)</font>', chitSource["familiar"]);
 	if(id.find())
 		bake(id.group(2), ensorceleeDescription(id.group(3)), "/images/"+id.group(1));
 	else

--- a/src/relay/chit_brickFamiliar.ash
+++ b/src/relay/chit_brickFamiliar.ash
@@ -943,7 +943,7 @@ string ensorceleeDescription(string kolProvided) {
 }
 
 # Thanks to Cannonfire40 for FamVampyre!
-# <p><font size=2><b>Ensorcelee:</b><br><img src=https://s3.amazonaws.com/images.kingdomofloathing.com/adventureimages/kg_sleepingguard.gif><br>Will Night<br><font color=blue><b>Blocks the first attack of each combat</font></b>
+# <p><font size=2><b>Ensorcelee:</b><br><img src=https://d2uyhvukfffg5a.cloudfront.net/adventureimages/olivers_gob.gif><br>Amelia Raven<br><font color=blue><b>Blocks the first attack of each combat</font>
 void FamVampyre() {
 	if(!have_skill($skill[Ensorcel]))
 		return;
@@ -967,7 +967,7 @@ void FamVampyre() {
 		result.append('</tbody></table>');
 	}
 
-	matcher id = create_matcher('https://s3.amazonaws.com/images.kingdomofloathing.com/(.+?)><br>(.+?)<br><font color=blue><b>(.+?)</font>', chitSource["familiar"]);
+	matcher id = create_matcher('https://d2uyhvukfffg5a.cloudfront.net/(.+?)><br>(.+?)<br><font color=blue><b>(.+?)</font>', chitSource["familiar"]);
 	if(id.find())
 		bake(id.group(2), ensorceleeDescription(id.group(3)), "/images/"+id.group(1));
 	else


### PR DESCRIPTION
# Description

Detect ensorcelee properly (it was matching on the pre-cloudfront URL).

Fixes # (issue)

## Screenshots
Before:
![image](https://github.com/user-attachments/assets/794cb012-5550-405e-8b15-128196010888)
After:
![image](https://github.com/user-attachments/assets/29a815b0-fa89-4577-a574-70aa02620840)

## Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/ChIT/tree/main) or have a good reason not to.
