### PR TITLE
fix: crash on recast arrows for zoot milks

### DIFF
--- a/src/relay/charpane.ash
+++ b/src/relay/charpane.ash
@@ -866,6 +866,7 @@ buff parseBuff(string source) {
 	string effectAlias = myBuff.effectName;
 	// temp(?) fix for %birdname%
 	columnArrow = columnArrow.replace_string("%birdname%", "bird");
+	columnArrow = columnArrow.replace_string(" %n ", " ");
 	// Add MP or item cost to increase effect
 	matcher howUp = create_matcher("cmd\\=((cast 1 )?(.+?))&pwd", url_decode(columnArrow));
 	if(howUp.find()) {


### PR DESCRIPTION
# Description
With effect replenishment arrows enabled, ChIT would crash when having the Milk of Cruelty / Kindness effects with
> java.lang.IllegalArgumentException: URLDecoder: Illegal hex characters in escape (%) pattern - Error at index 0 in: "n "

## Screenshots

Please include a screenshot both with and without your change active.

## Checklist:

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based by pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/ChIT/tree/main) or have a good reason not to.
