### PR TITLE
Add Everything Looks Color section to buffs block

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,9 +25,11 @@ Then install ChIT as normal.
 ## Uninstallation
 
 Run this command in the graphical CLI:
+
 ```
 git delete ChIT
 ```
+
 note that the above command is case sensitive. `chit` will not work it has to be `ChIT`
 
 ## What if I already have the sourceforge version installed?
@@ -129,12 +131,14 @@ Simply place your bricks in the area you want, in the order you want them.
   - Default: trail,quests,modifiers,elements,organs
 
 The roof, walls and floor of your house can use some special syntax to lay bricks out in rows and columns.
+
 - | separator places bricks or groups of bricks horizontally adjacent each other in a row
 - , separator starts a new row of bricks after the previous row
 - ( ) parens vertically group bricks
 - { } curly braces horizontally group bricks
 
 Overriding the width of a brick or group of bricks can be accomplished by adding the following suffix immediately after it:
+
 - :X% sets its width to X%.
 - :Xpx sets its width equal to X pixels.
 - :X\* sets its width to be X times wider than the default width of bricks in that row.
@@ -142,6 +146,7 @@ Overriding the width of a brick or group of bricks can be accomplished by adding
 If no width override is supplied, ChIT tries to make all bricks in the same row the same width, content allowing.
 
 examples:
+
 - character|gear:112px,stats:3\*|(familiar,trail):2\*
 - effects:2\*|(trail,gear,familiar,boombox)
 
@@ -332,6 +337,7 @@ Helpers are there merely for convenience; they will NOT try to auto-adventure fo
   - buffs - regular effects
   - intrinsics - intrinsic effects
   - songs - only if present, this will cause all active AT songs to be displayed separately. (And other limited quantity buffs like Boris and Jarlsberg)
+  - elx - only if present, this will cause all active "Everything looks \[color\]" cooldowns to be displayed separately.
   - advmods - Adventure Modifiers (currently just non-combat forcers)
   - Example:
     - intrinsics,limited,buffs - displays intrinsic effects first, then any AT songs, then all other effects/buffs

--- a/src/data/chit_effects.txt
+++ b/src/data/chit_effects.txt
@@ -128,12 +128,13 @@ Spooky VHS Tape Monster	style:"background-color:#D7D7FF;color:#007C29;font-style
 
 #He-Boulder Major Rays
 #Among many other things
-Everything Looks Blue	style:"color:blue"
-Everything Looks Red	style:"color:red"
-Everything Looks Yellow	style:"color:olive"
-Everything Looks Green	style:"color:green"
-Everything Looks Purple	style:"color:purple"
-Everything looks Beige	style:"color:burlywood"
+Everything Looks Blue	type:"elx", style:"color:blue"
+Everything Looks Red	type:"elx", style:"color:red"
+Everything Looks Yellow	type:"elx", style:"color:olive"
+Everything Looks Green	type:"elx", style:"color:green"
+Everything Looks Purple	type:"elx", style:"color:purple"
+Everything looks Beige	type:"elx", style:"color:burlywood"
+Everything looks Red, White and Blue	type:"elx"
 
 #Juju Mask
 Gaze of the Lightning God	style:"color:blue"

--- a/src/relay/charpane.ash
+++ b/src/relay/charpane.ash
@@ -1112,6 +1112,7 @@ void bakeEffects() {
 	buffer uniques;
 	buffer buffs;
 	buffer intrinsics;
+	buffer elx;
 	buffer helpers;
 	buffer advmods;
 	int total = 0;
@@ -1121,6 +1122,7 @@ void bakeEffects() {
 	string layout = vars["chit.effects.layout"].to_lower_case().replace_string(" ", "");
 	if (layout == "") layout = "buffs";
 	boolean showSongs = contains_text(layout,"songs");
+	boolean showELX = contains_text(layout,"elx");
 	if(!contains_text(layout, "advmods")) {
 		layout = "advmods," + layout;
 	}
@@ -1151,6 +1153,8 @@ void bakeEffects() {
 			uniques.append('<tbody class="buffs">');
 			uniques.append(currentBuff.effectHTML);
 			uniques.append('</tbody>');
+		} else if (showELX && currentBuff.effectType == "elx") {
+			elx.append(currentBuff.effectHTML);
 		} else {
 			buffs.append(currentBuff.effectHTML);
 		}
@@ -1331,6 +1335,7 @@ void bakeEffects() {
 				case "songs": result.append(songs); break;
 				case "intrinsics": result.append(intrinsics); break;
 				case "advmods": result.append(advmods); break;
+				case "elx": result.append(elx); break;
 				default: //ignore all other values
 			}
 		}


### PR DESCRIPTION
# Description

This change adds "elx" as an option to the effects block listing, functioning similarly to the "songs" option, creating a separate block with all the "Everything looks [color]" effects off on their own for ease of tracking.

## Screenshots

Before:
<img width="428" height="450" alt="image" src="https://github.com/user-attachments/assets/6573d754-dcdf-4901-a86f-121af5f9abd2" />

After:
<img width="445" height="525" alt="image" src="https://github.com/user-attachments/assets/daefe225-2a5b-45e0-a7b6-2d03f512cf86" />


## Checklist:

- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas. (In mimicking the style around it, I feel that it is self-explanatory but can change if required.
- [X] I have based by pull request against the [main branch](https://github.com/loathers/ChIT/tree/main) or have a good reason not to.
