### PR TITLE
Brinier Deepers only gives 20 of fishy now

### DIFF
--- a/src/relay/charpane.ash
+++ b/src/relay/charpane.ash
@@ -405,7 +405,7 @@ string helperLucky() {
 		rewards[$location[Ye Olde Medievale Villagee]] = "leather.gif|3 each: Straw, Leather and Clay|0";
 	if(get_property("kingLiberated") == "true") {
 		rewards[$location[An Octopus's Garden]] = "bigpearl.gif|Fight a moister oyster|148";
-		rewards[$location[The Brinier Deepers]] = "fish.gif|50 turns of fishy|0";
+		rewards[$location[The Brinier Deepers]] = "fish.gif|20 turns of fishy|0";
 		if(get_property("poolSharkCount").to_int() < 25)
 			rewards[$location[The Haunted Billiards Room]] = "poolcue.gif|Rack 'em up for permanent pool skill|0";
 		rewards[$location[Cobb's Knob Treasury]] = "adventureimages/kg_embezzler.gif|Fight an embezzler|20";


### PR DESCRIPTION
# Description

Changed the string from 50 turns to 20 turns of fishy when player has Lucky. This was [changed](https://kol.coldfront.net/thekolwiki/index.php/The_Haggling#History) after the new challenge path was introduced.

## Checklist:

- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas. (Not relevant)
- [X] I have based by pull request against the [main branch](https://github.com/loathers/ChIT/tree/main) or have a good reason not to.
